### PR TITLE
Change default api route

### DIFF
--- a/src/Imghoard/ImghoardClient.cs
+++ b/src/Imghoard/ImghoardClient.cs
@@ -146,7 +146,7 @@ namespace Imghoard
         public class Config
         {
             public string Tenancy { get; set; } = "prod";
-            public string Endpoint { get; set; } = "https://imgh.miki.ai/";
+            public string Endpoint { get; set; } = "https://api.miki.ai/";
 
             public static Config Default()
             {


### PR DESCRIPTION
`IMGH.MIKI.AI` is deprecated. Please consider using `API.MIKI.AI/IMAGES`